### PR TITLE
修复 - PHP 7.2及以上版本对于 create_function() 的提示

### DIFF
--- a/functions/functions-action.php
+++ b/functions/functions-action.php
@@ -584,8 +584,9 @@ function disable_emojis_tinymce( $plugins ) {
 // 去除头部版本号
 remove_action('wp_head', 'wp_generator'); 
 // 隐藏面板登陆错误信息
-add_filter('login_errors', create_function('$a', "return null;"));
-
+add_filter('login_errors', function ($a) {
+    return null;
+});
 // ajax头像更新
 add_action( 'init', 'ajax_avatar_url' );
 function ajax_avatar_url() {


### PR DESCRIPTION
对于 PHP 7.2 及以上版本，create_function() 被改为「不建议使用」，且会在 Debug 时出现此错误。
更改为匿名函数可解决此问题。
stackoverflow: [PHP 7.2 Function create_function() is deprecated](https://stackoverflow.com/questions/48161526/php-7-2-function-create-function-is-deprecated)